### PR TITLE
INDM Billboard ads

### DIFF
--- a/sites/foodmanufacturing/config/gam.js
+++ b/sites/foodmanufacturing/config/gam.js
@@ -4,13 +4,14 @@ const config = new GAMConfiguration('137873098', { basePath: 'FM' });
 
 config
   .setTemplate('LB', {
-    size: [[970, 250], [970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
+    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
     sizeMapping: [
-      { viewport: [980, 0], size: [[970, 250], [970, 90], [970, 66], [728, 90]] },
+      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
       { viewport: [750, 0], size: [728, 90] },
       { viewport: [320, 0], size: [[300, 50], [320, 50], [300, 100]] },
     ],
   })
+  .setTemplate('BILLBOARD', { size: [970, 250] })
   .setTemplate('CONTENT', { size: [[300, 250], [300, 600]] });
 
 config
@@ -20,6 +21,7 @@ config
     { name: 'rail1', templateName: 'CONTENT', path: 'default_rail1' },
     { name: 'rail2', templateName: 'CONTENT', path: 'default_rail2' },
     { name: 'load-more', templateName: 'CONTENT', path: 'default_load-more' },
+    { name: 'billboard', templateName: 'BILLBOARD', path: 'default_billboard' },
     { name: 'reskin', path: 'default_reskin' },
     { name: 'wa', path: 'default_wa' },
   ]);

--- a/sites/foodmanufacturing/server/styles/index.scss
+++ b/sites/foodmanufacturing/server/styles/index.scss
@@ -24,3 +24,10 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/orion/skin";
 // @todo this should be remove once contact us is in core
 @import "../../node_modules/@base-cms-websites/package-common/scss/contact-us-form";
+
+.ad-container {
+  &--bottom-of-page {
+    margin-top: $theme-ad-margin;
+    margin-bottom: $theme-ad-margin;
+  }
+}

--- a/sites/foodmanufacturing/server/templates/content/index.marko
+++ b/sites/foodmanufacturing/server/templates/content/index.marko
@@ -21,6 +21,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
+        "gpt-ad-billboard": GAM.getAdUnit({ name: "billboard", aliases }),
       }
       <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
@@ -115,6 +116,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     </marko-web-resolve-page>
   </@page>
   <@below-page>
+    <if(type !== "video")>
+      <marko-web-gam-display-ad id="gpt-ad-billboard" modifiers=["bottom-of-page"] />
+    </if>
     <marko-web-resolve-page|{ resolved, data: content }| node=pageNode>
       $ const section = resolved.getAsObject("primarySection");
       $ const aliases = hierarchyAliases(section);

--- a/sites/foodmanufacturing/server/templates/content/index.marko
+++ b/sites/foodmanufacturing/server/templates/content/index.marko
@@ -22,7 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
       }
-       <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
@@ -31,7 +31,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
     </marko-web-resolve-page>
-
   </@above-container>
   <@page>
     <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />

--- a/sites/impomag/config/gam.js
+++ b/sites/impomag/config/gam.js
@@ -4,13 +4,14 @@ const config = new GAMConfiguration('137873098', { basePath: 'IMPO' });
 
 config
   .setTemplate('LB', {
-    size: [[970, 250], [970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
+    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
     sizeMapping: [
-      { viewport: [980, 0], size: [[970, 250], [970, 90], [970, 66], [728, 90]] },
+      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
       { viewport: [750, 0], size: [728, 90] },
       { viewport: [320, 0], size: [[300, 50], [320, 50], [300, 100]] },
     ],
   })
+  .setTemplate('BILLBOARD', { size: [970, 250] })
   .setTemplate('CONTENT', { size: [[300, 250], [300, 600]] });
 
 config
@@ -20,6 +21,7 @@ config
     { name: 'rail1', templateName: 'CONTENT', path: 'default_rail1' },
     { name: 'rail2', templateName: 'CONTENT', path: 'default_rail2' },
     { name: 'load-more', templateName: 'CONTENT', path: 'default_load-more' },
+    { name: 'billboard', templateName: 'BILLBOARD', path: 'default_billboard' },
     { name: 'reskin', path: 'default_reskin' },
     { name: 'wa', path: 'default_wa' },
   ]);

--- a/sites/impomag/server/styles/index.scss
+++ b/sites/impomag/server/styles/index.scss
@@ -24,3 +24,10 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/orion/skin";
 // @todo this should be remove once contact us is in core
 @import "../../node_modules/@base-cms-websites/package-common/scss/contact-us-form";
+
+.ad-container {
+  &--bottom-of-page {
+    margin-top: $theme-ad-margin;
+    margin-bottom: $theme-ad-margin;
+  }
+}

--- a/sites/impomag/server/templates/content/index.marko
+++ b/sites/impomag/server/templates/content/index.marko
@@ -21,6 +21,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
+        "gpt-ad-billboard": GAM.getAdUnit({ name: "billboard", aliases }),
       }
       <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
@@ -115,6 +116,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     </marko-web-resolve-page>
   </@page>
   <@below-page>
+    <if(type !== "video")>
+      <marko-web-gam-display-ad id="gpt-ad-billboard" modifiers=["bottom-of-page"] />
+    </if>
     <marko-web-resolve-page|{ resolved, data: content }| node=pageNode>
       $ const section = resolved.getAsObject("primarySection");
       $ const aliases = hierarchyAliases(section);

--- a/sites/impomag/server/templates/content/index.marko
+++ b/sites/impomag/server/templates/content/index.marko
@@ -22,7 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
       }
-       <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
@@ -31,7 +31,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
     </marko-web-resolve-page>
-
   </@above-container>
   <@page>
     <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />

--- a/sites/inddist/config/gam.js
+++ b/sites/inddist/config/gam.js
@@ -4,13 +4,14 @@ const config = new GAMConfiguration('137873098', { basePath: 'INDT' });
 
 config
   .setTemplate('LB', {
-    size: [[970, 250], [970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
+    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
     sizeMapping: [
-      { viewport: [980, 0], size: [[970, 250], [970, 90], [970, 66], [728, 90]] },
+      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
       { viewport: [750, 0], size: [728, 90] },
       { viewport: [320, 0], size: [[300, 50], [320, 50], [300, 100]] },
     ],
   })
+  .setTemplate('BILLBOARD', { size: [970, 250] })
   .setTemplate('CONTENT', { size: [[300, 250], [300, 600]] });
 
 config
@@ -20,6 +21,7 @@ config
     { name: 'rail1', templateName: 'CONTENT', path: 'default_rail1' },
     { name: 'rail2', templateName: 'CONTENT', path: 'default_rail2' },
     { name: 'load-more', templateName: 'CONTENT', path: 'default_load-more' },
+    { name: 'billboard', templateName: 'BILLBOARD', path: 'default_billboard' },
     { name: 'reskin', path: 'default_reskin' },
     { name: 'wa', path: 'default_wa' },
   ]);

--- a/sites/inddist/server/styles/index.scss
+++ b/sites/inddist/server/styles/index.scss
@@ -26,3 +26,10 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/orion/skin";
 // @todo this should be remove once contact us is in core
 @import "../../node_modules/@base-cms-websites/package-common/scss/contact-us-form";
+
+.ad-container {
+  &--bottom-of-page {
+    margin-top: $theme-ad-margin;
+    margin-bottom: $theme-ad-margin;
+  }
+}

--- a/sites/inddist/server/templates/content/index.marko
+++ b/sites/inddist/server/templates/content/index.marko
@@ -21,6 +21,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
+        "gpt-ad-billboard": GAM.getAdUnit({ name: "billboard", aliases }),
       }
       <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
@@ -115,6 +116,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     </marko-web-resolve-page>
   </@page>
   <@below-page>
+    <if(type !== "video")>
+      <marko-web-gam-display-ad id="gpt-ad-billboard" modifiers=["bottom-of-page"] />
+    </if>
     <marko-web-resolve-page|{ resolved, data: content }| node=pageNode>
       $ const section = resolved.getAsObject("primarySection");
       $ const aliases = hierarchyAliases(section);

--- a/sites/inddist/server/templates/content/index.marko
+++ b/sites/inddist/server/templates/content/index.marko
@@ -22,7 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
       }
-       <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
@@ -31,7 +31,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
     </marko-web-resolve-page>
-
   </@above-container>
   <@page>
     <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />

--- a/sites/manufacturing/config/gam.js
+++ b/sites/manufacturing/config/gam.js
@@ -4,13 +4,14 @@ const config = new GAMConfiguration('137873098', { basePath: 'MNET' });
 
 config
   .setTemplate('LB', {
-    size: [[970, 250], [970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
+    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
     sizeMapping: [
-      { viewport: [980, 0], size: [[970, 250], [970, 90], [970, 66], [728, 90]] },
+      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
       { viewport: [750, 0], size: [728, 90] },
       { viewport: [320, 0], size: [[300, 50], [320, 50], [300, 100]] },
     ],
   })
+  .setTemplate('BILLBOARD', { size: [970, 250] })
   .setTemplate('CONTENT', { size: [[300, 250], [300, 600]] });
 
 config
@@ -20,6 +21,7 @@ config
     { name: 'rail1', templateName: 'CONTENT', path: 'default_rail1' },
     { name: 'rail2', templateName: 'CONTENT', path: 'default_rail2' },
     { name: 'load-more', templateName: 'CONTENT', path: 'default_load-more' },
+    { name: 'billboard', templateName: 'BILLBOARD', path: 'default_billboard' },
     { name: 'reskin', path: 'default_reskin' },
     { name: 'wa', path: 'default_wa' },
   ]);

--- a/sites/manufacturing/server/styles/index.scss
+++ b/sites/manufacturing/server/styles/index.scss
@@ -24,3 +24,10 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/orion/skin";
 // @todo this should be remove once contact us is in core
 @import "../../node_modules/@base-cms-websites/package-common/scss/contact-us-form";
+
+.ad-container {
+  &--bottom-of-page {
+    margin-top: $theme-ad-margin;
+    margin-bottom: $theme-ad-margin;
+  }
+}

--- a/sites/manufacturing/server/templates/content/index.marko
+++ b/sites/manufacturing/server/templates/content/index.marko
@@ -21,6 +21,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
+        "gpt-ad-billboard": GAM.getAdUnit({ name: "billboard", aliases }),
       }
       <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
@@ -115,6 +116,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     </marko-web-resolve-page>
   </@page>
   <@below-page>
+    <if(type !== "video")>
+      <marko-web-gam-display-ad id="gpt-ad-billboard" modifiers=["bottom-of-page"] />
+    </if>
     <marko-web-resolve-page|{ resolved, data: content }| node=pageNode>
       $ const section = resolved.getAsObject("primarySection");
       $ const aliases = hierarchyAliases(section);

--- a/sites/manufacturing/server/templates/content/index.marko
+++ b/sites/manufacturing/server/templates/content/index.marko
@@ -22,7 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
       }
-       <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
@@ -31,7 +31,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
     </marko-web-resolve-page>
-
   </@above-container>
   <@page>
     <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />

--- a/sites/mbtmag/config/gam.js
+++ b/sites/mbtmag/config/gam.js
@@ -4,13 +4,14 @@ const config = new GAMConfiguration('137873098', { basePath: 'MBT' });
 
 config
   .setTemplate('LB', {
-    size: [[970, 250], [970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
+    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
     sizeMapping: [
-      { viewport: [980, 0], size: [[970, 250], [970, 90], [970, 66], [728, 90]] },
+      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
       { viewport: [750, 0], size: [728, 90] },
       { viewport: [320, 0], size: [[300, 50], [320, 50], [300, 100]] },
     ],
   })
+  .setTemplate('BILLBOARD', { size: [970, 250] })
   .setTemplate('CONTENT', { size: [[300, 250], [300, 600]] });
 
 config
@@ -20,6 +21,7 @@ config
     { name: 'rail1', templateName: 'CONTENT', path: 'default_rail1' },
     { name: 'rail2', templateName: 'CONTENT', path: 'default_rail2' },
     { name: 'load-more', templateName: 'CONTENT', path: 'default_load-more' },
+    { name: 'billboard', templateName: 'BILLBOARD', path: 'default_billboard' },
     { name: 'reskin', path: 'default_reskin' },
     { name: 'wa', path: 'default_wa' },
   ]);

--- a/sites/mbtmag/server/styles/index.scss
+++ b/sites/mbtmag/server/styles/index.scss
@@ -24,3 +24,10 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/orion/skin";
 // @todo this should be remove once contact us is in core
 @import "../../node_modules/@base-cms-websites/package-common/scss/contact-us-form";
+
+.ad-container {
+  &--bottom-of-page {
+    margin-top: $theme-ad-margin;
+    margin-bottom: $theme-ad-margin;
+  }
+}

--- a/sites/mbtmag/server/templates/content/index.marko
+++ b/sites/mbtmag/server/templates/content/index.marko
@@ -21,6 +21,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
+        "gpt-ad-billboard": GAM.getAdUnit({ name: "billboard", aliases }),
       }
       <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
@@ -115,6 +116,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     </marko-web-resolve-page>
   </@page>
   <@below-page>
+    <if(type !== "video")>
+      <marko-web-gam-display-ad id="gpt-ad-billboard" modifiers=["bottom-of-page"] />
+    </if>
     <marko-web-resolve-page|{ resolved, data: content }| node=pageNode>
       $ const section = resolved.getAsObject("primarySection");
       $ const aliases = hierarchyAliases(section);

--- a/sites/mbtmag/server/templates/content/index.marko
+++ b/sites/mbtmag/server/templates/content/index.marko
@@ -22,7 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
       }
-       <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
@@ -31,7 +31,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
     </marko-web-resolve-page>
-
   </@above-container>
   <@page>
     <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />


### PR DESCRIPTION
Add billboard ad position to non-video content pages between the article body and load more.

Verified on on sites by including new ad units in an IEN placement, which has since been removed.

**Screenshots:**
![Screen Shot 2019-11-08 at 4 38 39 PM](https://user-images.githubusercontent.com/2855198/68515626-46ae8f00-0247-11ea-87de-b24c9d0a6080.png)
![Screen Shot 2019-11-08 at 4 34 41 PM](https://user-images.githubusercontent.com/2855198/68515627-46ae8f00-0247-11ea-8431-adbdbef10ba8.png)
![Screen Shot 2019-11-08 at 4 34 28 PM](https://user-images.githubusercontent.com/2855198/68515628-46ae8f00-0247-11ea-91c2-5014afbbdaed.png)
![Screen Shot 2019-11-08 at 4 32 44 PM](https://user-images.githubusercontent.com/2855198/68515629-46ae8f00-0247-11ea-9ed3-586bb915b8d3.png)
![Screen Shot 2019-11-08 at 3 16 15 PM](https://user-images.githubusercontent.com/2855198/68515630-46ae8f00-0247-11ea-8777-6f9486afda5c.png)
