### PR TITLE
Remove magazines from subscribe page and redirect link to wufoo forms

### DIFF
--- a/sites/foodmanufacturing.com/config/navigation.js
+++ b/sites/foodmanufacturing.com/config/navigation.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   secondary: {
     items: [
-      { href: '/subscribe', label: 'Subscribe' },
+      { href: 'https://ien.wufoo.com/forms/m1789xl4052dm1c/', label: 'Subscribe', target: '_blank' },
       { href: '/videos', label: 'Videos' },
     ],
   },
@@ -55,7 +55,7 @@ module.exports = {
     {
       label: 'User Tools',
       items: [
-        { href: '/subscribe', label: 'Subscribe' },
+        { href: 'https://ien.wufoo.com/forms/m1789xl4052dm1c/', label: 'Subscribe', target: '_blank' },
         { href: '/page/fm-advertise', label: 'Advertise' },
         { href: '/page/fm-about-us', label: 'About Us' },
         { href: '/contact-us', label: 'Contact Us' },

--- a/sites/foodmanufacturing.com/server/templates/subscribe/index.marko
+++ b/sites/foodmanufacturing.com/server/templates/subscribe/index.marko
@@ -41,17 +41,8 @@ $ const description = `${config.siteName()} has products that deliver powerful c
             <h4>Newsletters</h4>
             <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted newsletter offerings to stay informed on the topics that matter to you and your business.</p>
             <p><strong><marko-web-link href="https://ien.wufoo.com/forms/m1789xl4052dm1c/" target="_blank">Subscribe Now</marko-web-link></strong></p>
-            <hr>
           </div>
         </div>
-      </@section>
-      <@section>
-        <div class="row">
-          <div class="col mb-block">
-            <h4>Magazines</h4>
-          </div>
-        </div>
-        <website-magazine-publications-block />
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/sites/impomag.com/config/navigation.js
+++ b/sites/impomag.com/config/navigation.js
@@ -12,7 +12,7 @@ module.exports = {
   },
   secondary: {
     items: [
-      { href: '/subscribe', label: 'Subscribe' },
+      { href: 'https://ien.wufoo.com/forms/m3rig2e1uwzozj/', label: 'Subscribe', target: '_blank' },
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
     ],
@@ -55,7 +55,7 @@ module.exports = {
     {
       label: 'User Tools',
       items: [
-        { href: '/subscribe', label: 'Subscribe' },
+        { href: 'https://ien.wufoo.com/forms/m3rig2e1uwzozj/', label: 'Subscribe', target: '_blank' },
         { href: '/page/impo-advertise', label: 'Advertise' },
         { href: '/page/impo-about-us', label: 'About Us' },
         { href: '/contact-us', label: 'Contact Us' },

--- a/sites/impomag.com/server/templates/subscribe/index.marko
+++ b/sites/impomag.com/server/templates/subscribe/index.marko
@@ -41,17 +41,8 @@ $ const description = `${config.siteName()} has products that deliver powerful c
             <h4>Newsletters</h4>
             <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted newsletter offerings to stay informed on the topics that matter to you and your business.</p>
             <p><strong><marko-web-link href="https://ien.wufoo.com/forms/m3rig2e1uwzozj/" target="_blank">Subscribe Now</marko-web-link></strong></p>
-            <hr>
           </div>
         </div>
-      </@section>
-      <@section>
-        <div class="row">
-          <div class="col mb-block">
-            <h4>Magazines</h4>
-          </div>
-        </div>
-        <website-magazine-publications-block />
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/sites/inddist.com/server/templates/subscribe/index.marko
+++ b/sites/inddist.com/server/templates/subscribe/index.marko
@@ -41,17 +41,8 @@ $ const description = `${config.siteName()} has products that deliver powerful c
             <h4>Newsletters</h4>
             <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted newsletter offerings to stay informed on the topics that matter to you and your business.</p>
             <p><strong><marko-web-link href="https://ien.wufoo.com/forms/mlz32641lbd8mc/" target="_blank">Subscribe Now</marko-web-link></strong></p>
-            <hr>
           </div>
         </div>
-      </@section>
-      <@section>
-        <div class="row">
-          <div class="col mb-block">
-            <h4>Magazines</h4>
-          </div>
-        </div>
-        <website-magazine-publications-block />
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/sites/manufacturing.net/config/navigation.js
+++ b/sites/manufacturing.net/config/navigation.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   secondary: {
     items: [
-      { href: '/subscribe', label: 'Subscribe' },
+      { href: 'https://ien.wufoo.com/forms/mqmjm4213s3t6e/', label: 'Subscribe', target: '_blank' },
       { href: '/videos', label: 'Videos' },
     ],
   },
@@ -55,7 +55,7 @@ module.exports = {
     {
       label: 'User Tools',
       items: [
-        { href: '/subscribe', label: 'Subscribe' },
+        { href: 'https://ien.wufoo.com/forms/mqmjm4213s3t6e/', label: 'Subscribe', target: '_blank' },
         { href: '/page/mnet-advertise', label: 'Advertise' },
         { href: '/page/mnet-about-us', label: 'About Us' },
         { href: '/contact-us', label: 'Contact Us' },

--- a/sites/manufacturing.net/server/templates/subscribe/index.marko
+++ b/sites/manufacturing.net/server/templates/subscribe/index.marko
@@ -41,17 +41,8 @@ $ const description = `${config.siteName()} has products that deliver powerful c
             <h4>Newsletters</h4>
             <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted newsletter offerings to stay informed on the topics that matter to you and your business.</p>
             <p><strong><marko-web-link href="https://ien.wufoo.com/forms/mqmjm4213s3t6e/" target="_blank">Subscribe Now</marko-web-link></strong></p>
-            <hr>
           </div>
         </div>
-      </@section>
-      <@section>
-        <div class="row">
-          <div class="col mb-block">
-            <h4>Magazines</h4>
-          </div>
-        </div>
-        <website-magazine-publications-block />
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/sites/mbtmag.com/config/navigation.js
+++ b/sites/mbtmag.com/config/navigation.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   secondary: {
     items: [
-      { href: '/subscribe', label: 'Subscribe' },
+      { href: 'https://ien.wufoo.com/forms/m14o0t6z0foprwa/', label: 'Subscribe', target: '_blank' },
       { href: '/videos', label: 'Videos' },
     ],
   },
@@ -55,7 +55,7 @@ module.exports = {
     {
       label: 'User Tools',
       items: [
-        { href: '/subscribe', label: 'Subscribe' },
+        { href: 'https://ien.wufoo.com/forms/m14o0t6z0foprwa/', label: 'Subscribe', target: '_blank' },
         { href: '/page/mbt-advertise', label: 'Advertise' },
         { href: '/page/mbt-about-us', label: 'About Us' },
         { href: '/contact-us', label: 'Contact Us' },

--- a/sites/mbtmag.com/server/templates/subscribe/index.marko
+++ b/sites/mbtmag.com/server/templates/subscribe/index.marko
@@ -41,17 +41,8 @@ $ const description = `${config.siteName()} has products that deliver powerful c
             <h4>Newsletters</h4>
             <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted newsletter offerings to stay informed on the topics that matter to you and your business.</p>
             <p><strong><marko-web-link href="https://ien.wufoo.com/forms/m14o0t6z0foprwa/" target="_blank">Subscribe Now</marko-web-link></strong></p>
-            <hr>
           </div>
         </div>
-      </@section>
-      <@section>
-        <div class="row">
-          <div class="col mb-block">
-            <h4>Magazines</h4>
-          </div>
-        </div>
-        <website-magazine-publications-block />
       </@section>
     </marko-web-page-wrapper>
   </@page>


### PR DESCRIPTION
- Remove the Magazine block from `/subscribe`
- Change the secondary "Subscribe" nav link to point to the appropriate Wufoo form

[Original Jira Request](https://southcomm.atlassian.net/browse/BCMS-215?atlOrigin=eyJpIjoiMzAxZWM1NzMzMzU3NDNmYjkxNjQ2NDY0MDEwZjZhNWEiLCJwIjoiaiJ9)