### PR TITLE
Increase teaser max height to prevent text cutoff

### DIFF
--- a/packages/shared/scss/components/_node.scss
+++ b/packages/shared/scss/components/_node.scss
@@ -36,6 +36,12 @@
       font-size: 16px;
     }
 
+    &--teaser {
+      a {
+        max-height: 4.5rem;
+      }
+    }
+
     &--spec-guide-link-button + &--spec-guide-link-button {
       margin-top: .75rem;
     }


### PR DESCRIPTION
### Desktop Before:
<img width="1130" alt="before" src="https://user-images.githubusercontent.com/2855198/88459232-6e876680-ce59-11ea-88aa-06a9b19b95c1.png">

### Desktop After:
<img width="1075" alt="after" src="https://user-images.githubusercontent.com/2855198/88459249-8959db00-ce59-11ea-970f-0a192b5dd60a.png">

### Mobile Before:
<img width="499" alt="before-mobile" src="https://user-images.githubusercontent.com/2855198/88459256-95de3380-ce59-11ea-9653-e714180a0752.png">


### Mobile After:
<img width="490" alt="after-mobile" src="https://user-images.githubusercontent.com/2855198/88459264-9e366e80-ce59-11ea-83c4-76dd5a79cac0.png">
